### PR TITLE
update to zig master

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,8 @@ on:
   pull_request:
     branches:
       - main
+  schedule:
+    - cron: '0 0 * * *' # run at 00:00 UTC
 
 jobs:
   build_nix:

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,6 @@
 zig-cache
+zig-*
+wasmtime*
 .DS_Store
 *.swp
 .gyro

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # wasmtime-zig
-[<img alt="github" src="https://img.shields.io/badge/github-kubkon/wasmtime--zig-8da0cb?style=for-the-badge&labelColor=555555&logo=github" height="20">](https://github.com/kubkon/wasmtime-zig)
+[<img alt="github" src="https://img.shields.io/badge/github-zigwasm/wasmtime--zig-8da0cb?style=for-the-badge&labelColor=555555&logo=github" height="20">](https://github.com/kubkon/wasmtime-zig)
 [<img alt="build status" src="https://img.shields.io/github/workflow/status/kubkon/wasmtime-zig/CI/master?style=for-the-badge" height="20">](https://github.com/kubkon/wasmtime-zig/actions?query=branch%3Amaster)
 
 Zig embedding of [Wasmtime]
@@ -13,7 +13,7 @@ but expected, and things might just not work as expected yet.
 
 ## Building
 
-To build this library, you will need Zig nightly 0.8.0, as well as [`gyro`] package manager.
+To build this library, you will need Zig nightly 0.10.0, as well as [`gyro`] package manager (`v0.7.0`).
 
 [`gyro`]: https://github.com/mattnite/gyro
 

--- a/build.zig
+++ b/build.zig
@@ -30,13 +30,22 @@ pub fn build(b: *std.build.Builder) !void {
     simple_exe.setBuildMode(mode);
     simple_exe.addPackage(.{
         .name = "wasmtime",
-        .path = "src/main.zig",
+        .source = .{ .path = "src/main.zig" },
         .dependencies = &.{pkgs.wasm},
     });
-    if (builtin.os.tag == .windows) {
-        simple_exe.linkSystemLibrary("wasmtime.dll");
-    } else {
-        simple_exe.linkSystemLibrary("wasmtime");
+    switch (builtin.os.tag) {
+        .windows => {
+            simple_exe.linkSystemLibrary("wasmtime.dll");
+            simple_exe.linkSystemLibrary("unwind");
+        },
+        .linux => {
+            simple_exe.linkSystemLibrary("wasmtime");
+            simple_exe.linkSystemLibrary("unwind");
+        },
+        .macos => {
+            simple_exe.linkSystemLibrary("wasmtime");
+        },
+        else => unreachable,
     }
     simple_exe.linkLibC();
     simple_exe.step.dependOn(b.getInstallStep());

--- a/ci/install_gyro
+++ b/ci/install_gyro
@@ -1,0 +1,10 @@
+#!/bin/sh
+
+set -x
+set -e
+
+GYRO_VERSION=$1
+GYRO=$2
+
+curl -sL "https://github.com/mattnite/gyro/releases/download/$GYRO_VERSION/$GYRO.tar.gz" -o "$GYRO.tar.gz"
+tar xf "$GYRO.tar.gz"

--- a/ci/install_wasmtime
+++ b/ci/install_wasmtime
@@ -1,0 +1,10 @@
+#!/bin/sh
+
+set -x
+set -e
+
+WASMTIME_VERSION=$1
+WASMTIME=$2
+
+curl -sL "https://github.com/bytecodealliance/wasmtime/releases/download/$WASMTIME_VERSION/$WASMTIME.tar.xz" -o "$WASMTIME.tar.xz"
+tar xf "$WASMTIME.tar.xz"

--- a/ci/linux_ci
+++ b/ci/linux_ci
@@ -3,28 +3,29 @@
 set -x
 set -e
 
-ZIG="zig-linux-x86_64-0.8.0-dev.2667+44de88498"
-WASMTIME_VERSION="v0.24.0"
-WASMTIME="wasmtime-$WASMTIME_VERSION-x86_64-linux-c-api"
-GYRO_VERSION="0.2.3"
-GYRO="gyro-$GYRO_VERSION-linux-x86_64"
+ARCH="x86_64"
+OS="linux"
+ARCH_OS="${ARCH}-${OS}"
+OS_ARCH="${OS}-${ARCH}"
 
-wget -nv "https://ziglang.org/builds/$ZIG.tar.xz"
+ZIG_SRC="https://ziglang.org/download/index.json"
+ZIG_VERSION=$(curl -s ${ZIG_SRC} | jq -r '.master.version')
+ZIG="zig-${OS_ARCH}-$ZIG_VERSION"
+ZIG_MASTER=$(curl -s ${ZIG_SRC} | jq -r --arg ARCH_OS "$ARCH_OS" '.master[$ARCH_OS].tarball')
+
+WASMTIME_VERSION="v0.24.0"
+WASMTIME="wasmtime-$WASMTIME_VERSION-${ARCH_OS}-c-api"
+GYRO_VERSION="0.7.0"
+GYRO="gyro-$GYRO_VERSION-${OS_ARCH}"
+
+# TODO: make this nice
+curl -sL "${ZIG_MASTER}" -o "$ZIG.tar.xz"
 tar xf "$ZIG.tar.xz"
 export PATH="$(pwd)/$ZIG:$PATH"
 
-wget -nv "https://github.com/bytecodealliance/wasmtime/releases/download/$WASMTIME_VERSION/$WASMTIME.tar.xz"
-tar xf "$WASMTIME.tar.xz"
+./ci/install_wasmtime $WASMTIME_VERSION $WASMTIME
 
-wget -nv "https://github.com/mattnite/gyro/releases/download/$GYRO_VERSION/$GYRO.tar.gz"
-tar xf "$GYRO.tar.gz"
+./ci/install_gyro $GYRO_VERSION $GYRO
 export PATH="$(pwd)/$GYRO/bin:$PATH"
 
-gyro build
-gyro build test
-gyro build run -Dexample=simple --search-prefix "$(pwd)/$WASMTIME"
-gyro build run -Dexample=gcd --search-prefix "$(pwd)/$WASMTIME"
-gyro build run -Dexample=linking --search-prefix "$(pwd)/$WASMTIME"
-gyro build run -Dexample=memory --search-prefix "$(pwd)/$WASMTIME"
-gyro build run -Dexample=interrupt --search-prefix "$(pwd)/$WASMTIME"
-
+./ci/run_gyro $WASMTIME

--- a/ci/macos_ci
+++ b/ci/macos_ci
@@ -3,28 +3,28 @@
 set -x
 set -e
 
-ZIG="zig-macos-x86_64-0.8.0-dev.2670+d8d92dafe"
+ARCH="x86_64"
+OS="macos"
+ARCH_OS="${ARCH}-${OS}"
+OS_ARCH="${OS}-${ARCH}"
+
+ZIG_SRC="https://ziglang.org/download/index.json"
+ZIG_VERSION=$(curl -s ${ZIG_SRC} | jq -r '.master.version')
+ZIG="zig-${OS_ARCH}-$ZIG_VERSION"
+ZIG_MASTER=$(curl -s ${ZIG_SRC} | jq -r --arg ARCH_OS "$ARCH_OS" '.master[$ARCH_OS].tarball')
+
 WASMTIME_VERSION="v0.24.0"
 WASMTIME="wasmtime-$WASMTIME_VERSION-x86_64-macos-c-api"
-GYRO_VERSION="0.2.3"
+GYRO_VERSION="0.7.0"
 GYRO="gyro-$GYRO_VERSION-macos-x86_64"
 
-curl -L "https://ziglang.org/builds/$ZIG.tar.xz" -o "$ZIG.tar.xz"
+curl -sL "${ZIG_MASTER}" -o "$ZIG.tar.xz"
 tar xf "$ZIG.tar.xz"
 export PATH="$(pwd)/$ZIG:$PATH"
 
-curl -L "https://github.com/bytecodealliance/wasmtime/releases/download/$WASMTIME_VERSION/$WASMTIME.tar.xz" -o "$WASMTIME.tar.xz"
-tar xf "$WASMTIME.tar.xz"
+./ci/install_wasmtime $WASMTIME_VERSION $WASMTIME
 
-curl -L "https://github.com/mattnite/gyro/releases/download/$GYRO_VERSION/$GYRO.tar.gz" -o "$GYRO.tar.gz"
-tar xf "$GYRO.tar.gz"
+./ci/install_gyro $GYRO_VERSION $GYRO
 export PATH="$(pwd)/$GYRO/bin:$PATH"
 
-gyro build
-gyro build test
-gyro build run -Dexample=simple --search-prefix "$(pwd)/$WASMTIME"
-gyro build run -Dexample=gcd --search-prefix "$(pwd)/$WASMTIME"
-gyro build run -Dexample=linking --search-prefix "$(pwd)/$WASMTIME"
-gyro build run -Dexample=memory --search-prefix "$(pwd)/$WASMTIME"
-gyro build run -Dexample=interrupt --search-prefix "$(pwd)/$WASMTIME"
-
+./ci/run_gyro $WASMTIME

--- a/ci/run_gyro
+++ b/ci/run_gyro
@@ -1,0 +1,14 @@
+#!/bin/sh
+
+set -x
+set -e
+
+WASMTIME=$1
+
+gyro build
+gyro build test
+gyro build run -Dexample=simple --search-prefix "$(pwd)/$WASMTIME"
+gyro build run -Dexample=gcd --search-prefix "$(pwd)/$WASMTIME"
+gyro build run -Dexample=linking --search-prefix "$(pwd)/$WASMTIME"
+gyro build run -Dexample=memory --search-prefix "$(pwd)/$WASMTIME"
+gyro build run -Dexample=interrupt --search-prefix "$(pwd)/$WASMTIME"

--- a/ci/win_ci
+++ b/ci/win_ci
@@ -3,28 +3,30 @@
 set -x
 set -e
 
-ZIG="zig-windows-x86_64-0.8.0-dev.2667+44de88498"
-WASMTIME_VERSION="v0.24.0"
-WASMTIME="wasmtime-$WASMTIME_VERSION-x86_64-windows-c-api"
-GYRO_VERSION="0.2.3"
-GYRO="gyro-$GYRO_VERSION-windows-x86_64"
+ARCH="x86_64"
+OS="windows"
+ARCH_OS="${ARCH}-${OS}"
+OS_ARCH="${OS}-${ARCH}"
 
-curl -L "https://ziglang.org/builds/$ZIG.zip" -o "$ZIG.zip"
+ZIG_SRC="https://ziglang.org/download/index.json"
+ZIG_VERSION=$(curl -s ${ZIG_SRC} | jq -r '.master.version')
+ZIG="zig-${OS_ARCH}-$ZIG_VERSION"
+ZIG_MASTER=$(curl -s ${ZIG_SRC} | jq -r --arg ARCH_OS "$ARCH_OS" '.master[$ARCH_OS].tarball')
+
+WASMTIME_VERSION="v0.24.0"
+WASMTIME="wasmtime-$WASMTIME_VERSION-${ARCH_OS}-c-api"
+GYRO_VERSION="0.7.0"
+GYRO="gyro-$GYRO_VERSION-${OS_ARCH}"
+
+curl -sL "${ZIG_MASTER}" -o "$ZIG.zip"
 7z x "$ZIG.zip"
 export PATH="$(pwd)/$ZIG:$PATH"
 
-curl -L "https://github.com/bytecodealliance/wasmtime/releases/download/$WASMTIME_VERSION/$WASMTIME.zip" -o "$WASMTIME.zip"
+curl -sL "https://github.com/bytecodealliance/wasmtime/releases/download/$WASMTIME_VERSION/$WASMTIME.zip" -o "$WASMTIME.zip"
 7z x "$WASMTIME.zip"
 
-curl -L "https://github.com/mattnite/gyro/releases/download/$GYRO_VERSION/$GYRO.zip" -o "$GYRO.zip"
+curl -sL "https://github.com/mattnite/gyro/releases/download/$GYRO_VERSION/$GYRO.zip" -o "$GYRO.zip"
 7z x "$GYRO.zip"
 export PATH="$(pwd)/$GYRO/bin:$PATH"
 
-gyro build
-gyro build test
-gyro build run -Dexample=simple --search-prefix "$(pwd)/$WASMTIME"
-gyro build run -Dexample=gcd --search-prefix "$(pwd)/$WASMTIME"
-gyro build run -Dexample=linking --search-prefix "$(pwd)/$WASMTIME"
-gyro build run -Dexample=memory --search-prefix "$(pwd)/$WASMTIME"
-gyro build run -Dexample=interrupt --search-prefix "$(pwd)/$WASMTIME"
-
+./ci/run_gyro $WASMTIME

--- a/examples/interrupt.zig
+++ b/examples/interrupt.zig
@@ -38,7 +38,7 @@ pub fn main() !void {
     defer instance.deinit();
     std.debug.print("Instance initialized...\n", .{});
 
-    const thread = try std.Thread.spawn(interrupt, handle);
+    const thread = try std.Thread.spawn(.{}, interrupt, .{ handle });
 
     if (instance.getExportFunc(module, "run")) |f| {
         std.debug.print("Calling export...\n", .{});
@@ -50,5 +50,5 @@ pub fn main() !void {
         std.debug.print("Export not found...\n", .{});
     }
 
-    thread.wait();
+    thread.join();
 }

--- a/examples/linking.zig
+++ b/examples/linking.zig
@@ -1,6 +1,6 @@
 const std = @import("std");
 const wasmtime = @import("wasmtime");
-const builtin = std.builtin;
+const builtin = @import("builtin");
 const fs = std.fs;
 const ga = std.heap.c_allocator;
 const Allocator = std.mem.Allocator;

--- a/gyro.zzz
+++ b/gyro.zzz
@@ -1,7 +1,6 @@
 pkgs:
   wasmtime:
     version: 0.0.0
-    root: src/main.zig
     description: Zig embedding of Wasmtime
     license: Apache-2.0
     source_url: "https://github.com/zigwasm/wasmtime-zig"
@@ -9,10 +8,10 @@ pkgs:
       wasmtime
       wasm
       wasi
+    root: src/main.zig
 deps:
   wasm:
-    src:
-      github:
-        user: zigwasm
-        repo: wasm-zig
-        ref: main
+    git:
+      url: "https://github.com/zigwasm/wasm-zig.git"
+      ref: main
+      root: src/main.zig

--- a/src/main.zig
+++ b/src/main.zig
@@ -69,14 +69,14 @@ pub const Module = struct {
     inner: *wasm.Module,
 
     /// Initializes a new `Module` using the supplied engine and wasm bytecode
-    pub fn initFromWasm(engine: *Engine, wasm: []const u8) !Module {
-        var wasm_bytes = ByteVec.initWithCapacity(wasm.len);
+    pub fn initFromWasm(engine: *Engine, _wasm: []const u8) !Module {
+        var wasm_bytes = ByteVec.initWithCapacity(_wasm.len);
         defer wasm_bytes.deinit();
 
         var i: usize = 0;
         var ptr = wasm_bytes.data;
-        while (i < wasm.len) : (i += 1) {
-            ptr.* = wasm[i];
+        while (i < _wasm.len) : (i += 1) {
+            ptr.* = _wasm[i];
             ptr += 1;
         }
 
@@ -163,8 +163,8 @@ pub const Func = struct {
         comptime var wasm_args: [args_len]Value = undefined;
         inline for (wasm_args) |*arg, i| {
             arg.* = switch (@TypeOf(args[i])) {
-                i32, u32 => .{ .kind = .i32, .of = .{ .i32 = @intCast(i32, args[i]) } },
-                i64, u64 => .{ .kind = .i64, .of = .{ .i64 = @intCast(i64, args[i]) } },
+                i32, u32 => .{ .kind = .i32, .of = .{ .i32 = @bitCast(i32, args[i]) } },
+                i64, u64 => .{ .kind = .i64, .of = .{ .i64 = @bitCast(i64, args[i]) } },
                 f32 => .{ .kind = .f32, .of = .{ .f32 = args[i] } },
                 f64 => .{ .kind = .f64, .of = .{ .f64 = args[i] } },
                 *Func => .{ .kind = .funcref, .of = .{ .ref = args[i] } },
@@ -216,7 +216,7 @@ pub const Func = struct {
             f32 => result_ty.of.f32,
             f64 => result_ty.of.f64,
             *Func => @ptrCast(?*Func, result_ty.of.ref).?,
-            *Extern => @ptrCast(?*c.Extern, result_ty.of.ref).?,
+            *Extern => @ptrCast(?*Extern, result_ty.of.ref).?,
             else => |ty| @compileError("Unsupported result type '" ++ @typeName(ty) ++ "'"),
         };
     }
@@ -296,6 +296,7 @@ pub const InterruptHandle = opaque {
     }
     /// Invokes an interrupt in the current wasm module
     pub fn interrupt(self: *InterruptHandle) void {
+        std.debug.print("> INTERRUPTING! \n", .{});
         wasmtime_interrupt_handle_interrupt(self);
     }
 


### PR DESCRIPTION
The goal of this PR is to

* build with the latest version of zig (`master`)
* update dependency management via gyro to `0.7.0`
* decouple CI commands, so they can be used better for local testing
* add a daily schedule to run tests every day

Whats working:

| Test | Linux | MacOS | Windows |
| ---- | ----- | ----- | ------- | 
| simple | ✅ | ✅ | ❌ |
| gcd | ✅ | ✅ | ❌ |
| linking | ✅ | ✅ | ❌ |
| memory | ✅ | ✅ | ❌ |
| interrupt | ✅ | ✅ | ❌ |
